### PR TITLE
Fix member card clipping

### DIFF
--- a/frontend/src/components/team/MemberCard.tsx
+++ b/frontend/src/components/team/MemberCard.tsx
@@ -74,16 +74,14 @@ export default function MemberCard({ member }: { member: Member }) {
 
   return (
     <div
-      className="w-full max-w-[280px] h-[390px] sm:h-[410px] mx-auto my-5"
+      className="w-full max-w-[280px] aspect-[280/360] mx-auto my-5"
       style={{ perspective: 1200 }}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       onClick={handleClick}
     >
       <div
-        className={`relative w-full h-full rounded-3xl transition-all duration-700 ${
-          hover ? "shadow-2xl shadow-blue-200/40" : "shadow-lg shadow-gray-200/60"
-        }`}
+        className="relative w-full h-full rounded-3xl transition-all duration-700"
         style={{
           transformStyle: "preserve-3d",
           transform: hover ? "rotateY(180deg)" : "rotateY(0deg)",
@@ -91,7 +89,7 @@ export default function MemberCard({ member }: { member: Member }) {
       >
         {/* ================= FRONT ================= */}
         <div
-          className="absolute inset-0 bg-white rounded-3xl border border-gray-200 flex flex-col items-center px-7 pt-12 pb-5 h-full"
+          className="absolute inset-0 bg-white rounded-3xl border border-gray-200 flex flex-col items-center px-7 pt-9 h-fit"
           style={{ backfaceVisibility: "hidden" }}
         >
           {/* Profile Image */}


### PR DESCRIPTION
- [x]  I read the Generative AI policy of NSS IIIT Hyderabad Open Source Community
 
## Summary of Changes

1. Card face size fixing ->  fixed the face card size for all cards to a fixed height  (Assuming max length of names would be around 3 lines in the card)
2. Added padding in the top of the card to improve the looks of the card

## Related Issue
Fixes #22 

## Testing Instructions
Open the members page.
Verify on desktop and mobile viewport (DevTools device mode).
Hover and confirm no partial extra card appears below.

## Actual result BEFORE applying this Pull Request
Some cards are having clipping because of the due to different length of names and improper scaling.
And due to different sizing of back side container and the front side the clipping is happening

## Expected result AFTER applying this Pull Request
No clipping in the cards 
Only one card is visible

## Screenshots 
After Fix:
In PC:
<img width="297" height="493" alt="image" src="https://github.com/user-attachments/assets/0e6382ff-a3bd-4e57-93e7-24d88d5b6c0c" />

In Mobile:
<img width="407" height="835" alt="image" src="https://github.com/user-attachments/assets/d38ebf92-9700-45d9-b4cf-b5e09091bd2d" />


## Checklist (x to check the box)]
- [x] Tests added/updated
- [x] No breaking changes


